### PR TITLE
Add file synchronization to coordinate targets

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -74,7 +74,7 @@
                 <path refid="application"/>
             </classpath>
             <test name="main.AllTests"/>
-            <formatter type="plain" usefile="false"/>
+            <formatter type="brief" usefile="false"/>
         </junit>
     </target>
 

--- a/source/expression/Expression.java
+++ b/source/expression/Expression.java
@@ -17,6 +17,9 @@ package expression;
 
 import main.IMatch;
 import main.ITarget;
+import main.Utilities;
+
+import java.util.List;
 
 public abstract class Expression implements IExpression {
 
@@ -28,5 +31,12 @@ public abstract class Expression implements IExpression {
         mTarget = target;
     }
 
-    public abstract String resolve();
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<String> resolveList() {
+        return Utilities.newList(resolve());
+    }
+
 }

--- a/source/expression/ExpressionList.java
+++ b/source/expression/ExpressionList.java
@@ -17,12 +17,12 @@ package expression;
 
 import main.IMatch;
 import main.ITarget;
+import main.Utilities;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class ExpressionList extends Expression {
-
-    public static final String SEPARATOR = ";";
 
     private List<IExpression> mElements;
 
@@ -31,17 +31,23 @@ public class ExpressionList extends Expression {
         mElements = elements;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public String resolve() {
-        StringBuilder values = new StringBuilder();
-        boolean first = true;
+        return Utilities.join(" ", resolveList());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<String> resolveList() {
+        List<String> values = new ArrayList<String>();
         for (IExpression element : mElements) {
-            if (first) {
-                first = false;
-            } else {
-                values.append(SEPARATOR);
-            }
-            values.append(element.resolve());
+            values.addAll(element.resolveList());
         }
-        return values.toString();
+        return values;
     }
 }

--- a/source/expression/IExpression.java
+++ b/source/expression/IExpression.java
@@ -18,10 +18,17 @@ package expression;
 import main.IMatch;
 import main.ITarget;
 
+import java.util.List;
+
 public interface IExpression {
 
     /**
      * Resolves the expression to a string.
      */
     String resolve();
+
+    /**
+     * Resolves the expression to a list of strings.
+     */
+    List<String> resolveList();
 }

--- a/source/expression/Literal.java
+++ b/source/expression/Literal.java
@@ -18,6 +18,8 @@ package expression;
 import main.IMatch;
 import main.ITarget;
 
+import java.util.List;
+
 public class Literal extends Expression {
 
     private String mValue;
@@ -27,6 +29,10 @@ public class Literal extends Expression {
         mValue = value;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public String resolve() {
         return mValue;
     }

--- a/source/expression/function/Function.java
+++ b/source/expression/function/Function.java
@@ -28,6 +28,14 @@ import java.util.Map;
 public abstract class Function extends Expression implements IFunction {
 
     public static final String ANONYMOUS = "_";
+    public static final String CLASS_OUTPUT = "build/java/classes";
+    public static final String DIRECTORY = "directory";
+    public static final String JAR_OUTPUT = "build/java/jar";
+    public static final String LIBRARY = "library";
+    public static final String NAME = "name";
+    public static final String PATTERN = "pattern";
+    public static final String SOURCE = "source";
+    public static final String VALUE = "value";
 
     private Map<String, IExpression> mParameters = new HashMap<String, IExpression>();
 
@@ -37,15 +45,38 @@ public abstract class Function extends Expression implements IFunction {
     }
 
     /**
-     * {inheritDoc}
+     * {@inheritDoc}
      */
+    @Override
+    public void setUp() {}
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String resolve() {
+        mMatch.error("Function does not resolve to a single String");
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void tearDown() {}
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public boolean hasParameter(String key) {
         return mParameters.containsKey(key);
     }
 
     /**
-     * {inheritDoc}
+     * {@inheritDoc}
      */
+    @Override
     public IExpression getParameter(String key) {
         IExpression parameter =  mParameters.get(key);
         if (parameter == null) {
@@ -70,4 +101,5 @@ public abstract class Function extends Expression implements IFunction {
             return null;
         }
     }
+
 }

--- a/source/expression/function/GetFile.java
+++ b/source/expression/function/GetFile.java
@@ -23,16 +23,16 @@ import main.Match;
 
 import java.util.Map;
 
-public class Get extends Function {
+public class GetFile extends Get {
 
     private String mKey;
 
-    public Get(IMatch match, ITarget target, Map<String, IExpression> parameters) {
+    public GetFile(IMatch match, ITarget target, Map<String, IExpression> parameters) {
         super(match, target, parameters);
         String parameterName = hasParameter(NAME) ? NAME : ANONYMOUS;
         IExpression key = getParameter(parameterName);
         if (!(key instanceof Literal)) {
-            mMatch.error("Get function expects a String key");
+            mMatch.error("GetFile expects a String key");
         }
         mKey = key.resolve();
     }
@@ -42,6 +42,8 @@ public class Get extends Function {
      */
     @Override
     public String resolve() {
-        return mMatch.getProperty(mKey);
+        String file = mMatch.getProperty(mKey);
+        mMatch.awaitFile(file);
+        return file;
     }
 }

--- a/source/expression/function/IFunction.java
+++ b/source/expression/function/IFunction.java
@@ -20,12 +20,22 @@ import expression.IExpression;
 public interface IFunction extends IExpression {
 
     /**
-     * Returns true if a parameter of the given key was passed to this function.
+     * Sets up the environment
+     */
+    void setUp();
+
+    /**
+     * Tears down the environment
+     */
+    void tearDown();
+
+    /**
+     * Returns true iff the parameter map has the given key.
      */
     boolean hasParameter(String key);
 
     /**
-     * Gets the parameter for the given key.
+     * Returns the parameter for the given key.
      */
     IExpression getParameter(String key);
 }

--- a/source/expression/function/JavaJar.java
+++ b/source/expression/function/JavaJar.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2015 Stuart Scott
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package expression.function;
+
+import expression.IExpression;
+import expression.Literal;
+import main.IMatch;
+import main.ITarget;
+import main.Match;
+import main.Utilities;
+
+import java.util.Map;
+
+public class JavaJar extends Function {
+
+    private static final String MANIFEST_VERSION = "Manifest-Version: 1.0";
+    private static final String MANIFEST_MAIN_CLASS = "Main-Class: %s";
+    private static final String MANIFEST_CLASS_PATH = "Class-Path: %s";
+    private static final String ECHO_COMMAND = "echo %s";
+    private static final String COMMAND = "mkdir -p %s && javac %s %s -d %s && cd %s && jar cfm %s %s %s";
+
+    private String mName;
+    private String mManifest;
+    private String mIntermediate;
+    private String mOutput;
+
+    public JavaJar(IMatch match, ITarget target, Map<String, IExpression> parameters) {
+        super(match, target, parameters);
+        IExpression name = getParameter(NAME);
+        if (!(name instanceof Literal)) {
+            mMatch.error("JavaJar function expects a String name");
+        }
+        mName = name.resolve();
+        mOutput = String.format("%s/%s.jar", JAR_OUTPUT, mName);
+        mIntermediate = String.format("%s/%s", CLASS_OUTPUT, mName);
+        mManifest = String.format("%s/MANIFEST.MF", mIntermediate, mName);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setUp() {
+        mMatch.addFile(mManifest);
+        mMatch.addFile(mOutput);
+        mMatch.setProperty(mName, mOutput);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String resolve() {
+        String directories = String.format("{%s,%s}", mIntermediate, JAR_OUTPUT);
+        String classpath = "";
+        if (hasParameter(LIBRARY)) {
+            classpath = String.format("-cp %s", Utilities.join(":", getParameter(LIBRARY).resolveList()));
+        }
+        String files = Utilities.join(" ", getParameter(SOURCE).resolveList());
+        mMatch.runCommand(String.format(COMMAND, directories, classpath, files, mIntermediate, mIntermediate, mOutput, mManifest, mIntermediate));
+        mMatch.provideFile(mOutput);
+        return mOutput;
+    }
+}

--- a/source/expression/function/Set.java
+++ b/source/expression/function/Set.java
@@ -16,6 +16,7 @@
 package expression.function;
 
 import expression.IExpression;
+import expression.Literal;
 import main.IMatch;
 import main.ITarget;
 import main.Match;
@@ -25,18 +26,35 @@ import java.util.Map;
 public class Set extends Function {
 
     private String mKey;
+    private String mValue;
 
     public Set(IMatch match, ITarget target, Map<String, IExpression> parameters) {
         super(match, target, parameters);
-        if (parameters.size() != 1) {
-            mMatch.error("Set needs a key and value to set\nset(foo = \"bar\")");
+        IExpression key = getParameter(NAME);
+        IExpression value = getParameter(VALUE);
+        if (!(key instanceof Literal)) {
+            mMatch.error("Set function expects a String key");
         }
-        mKey = parameters.keySet().iterator().next();
+        if (!(value instanceof Literal)) {
+            mMatch.error("Set function expects a String value");
+        }
+        mKey = key.resolve();
+        mValue = value.resolve();
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setUp() {
+        mMatch.setProperty(mKey, mValue);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public String resolve() {
-        String value = getParameter(mKey).resolve();
-        mMatch.setProperty(mKey, value);
-        return value;
+        return mValue;
     }
 }

--- a/source/expression/function/SetFile.java
+++ b/source/expression/function/SetFile.java
@@ -21,20 +21,40 @@ import main.IMatch;
 import main.ITarget;
 import main.Match;
 
+import java.io.File;
 import java.util.Map;
 
-public class Get extends Function {
+public class SetFile extends Set {
 
     private String mKey;
+    private String mValue;
 
-    public Get(IMatch match, ITarget target, Map<String, IExpression> parameters) {
+    public SetFile(IMatch match, ITarget target, Map<String, IExpression> parameters) {
         super(match, target, parameters);
-        String parameterName = hasParameter(NAME) ? NAME : ANONYMOUS;
-        IExpression key = getParameter(parameterName);
+        IExpression key = getParameter(NAME);
+        IExpression value = getParameter(VALUE);
         if (!(key instanceof Literal)) {
-            mMatch.error("Get function expects a String key");
+            mMatch.error("SetFile expects a String key");
+        }
+        if (!(value instanceof Literal)) {
+            mMatch.error("SetFile expects a String value");
         }
         mKey = key.resolve();
+        mValue = value.resolve();
+        File file = new File(mValue);
+        if (!file.exists()) {
+            mMatch.error(String.format("File %s does not exist", file));
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setUp() {
+        mMatch.setProperty(mKey, mValue);
+        mMatch.addFile(mValue);
+        mMatch.provideFile(mValue);
     }
 
     /**
@@ -42,6 +62,6 @@ public class Get extends Function {
      */
     @Override
     public String resolve() {
-        return mMatch.getProperty(mKey);
+        return mValue;
     }
 }

--- a/source/frontend/Lexem.java
+++ b/source/frontend/Lexem.java
@@ -25,6 +25,10 @@ public class Lexem {
         this.mRegex = regex;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public String toString() {
         return mCategory + " : " + mRegex;
     }

--- a/source/frontend/Token.java
+++ b/source/frontend/Token.java
@@ -33,6 +33,10 @@ public class Token {
         mValue = value;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public String toString() {
         return mCategory + " : " + mValue;
     }

--- a/source/main/IMatch.java
+++ b/source/main/IMatch.java
@@ -46,4 +46,26 @@ public interface IMatch {
      * Aborts the build and prints the exception to the console.
      */
     void error(Exception exception);
+
+    /**
+     * Adds the given file to the target's output file.
+     */
+    void addFile(String file);
+
+    /**
+     * Called when a file is ready to be used by other target.
+     *
+     * This will allow all targets that are awaiting this file to continue.
+     */
+    void provideFile(String file);
+
+    /**
+     * Waits until the given file has been created.
+     */
+    void awaitFile(String file);
+
+    /**
+     * Runs the given command.
+     */
+    void runCommand(String command);
 }

--- a/source/main/ITarget.java
+++ b/source/main/ITarget.java
@@ -25,7 +25,17 @@ public interface ITarget {
     void setFunction(IFunction function);
 
     /**
-     * Does the steps necessary to build this target.
+     * Set up the environment to build this target.
+     */
+    void setUp();
+
+    /**
+     * Build this target.
      */
     void build();
+
+    /**
+     * Tear down anything that was temporary.
+     */
+    void tearDown();
 }

--- a/source/main/Match.java
+++ b/source/main/Match.java
@@ -25,9 +25,10 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
 
 public class Match implements IMatch {
 
@@ -48,12 +49,12 @@ public class Match implements IMatch {
 
     private File mRoot;
 
-    // TODO needs to be synchronized
-    private Map<String, String> mProperties = new HashMap<String, String>();
+    private Map<String, String> mProperties = new ConcurrentHashMap<String, String>();
+    private Map<String, CountDownLatch> mFiles = new ConcurrentHashMap<String, CountDownLatch>();
     private final List<File> mMatchFiles = new ArrayList<File>();
     private final List<File> mAllFiles = new ArrayList<File>();
 
-    Match(File root) {
+    public Match(File root) {
         mRoot = root;
     }
 
@@ -87,8 +88,42 @@ public class Match implements IMatch {
     @Override
     public void setProperty(String key, String value) {
         mProperties.put(key, value);
-        // Notify everyone who may have been waiting on this.
-        notifyAll();
+    }
+
+    /**
+     * {inheritDoc}
+     */
+    @Override
+    public void addFile(String file) {
+        mFiles.put(file, new CountDownLatch(1));
+    }
+
+    /**
+     * {inheritDoc}
+     */
+    @Override
+    public void provideFile(String file) {
+        CountDownLatch latch = mFiles.get(file);
+        if (latch == null) {
+            error(String.format("provideFile called before addFile for %s", file));
+        }
+        latch.countDown();
+    }
+
+    /**
+     * {inheritDoc}
+     */
+    @Override
+    public void awaitFile(String file) {
+        CountDownLatch latch = mFiles.get(file);
+        if (latch == null) {
+            error(String.format("no targets provided %s", file));
+        }
+        try {
+            latch.await();
+        } catch(InterruptedException e) {
+            error("target interrupted");
+        }
     }
 
     private void loadFiles(File directory) {
@@ -106,8 +141,6 @@ public class Match implements IMatch {
 
     void light() {
         loadFiles(mRoot);
-        System.out.println("All files: " + mAllFiles);
-        System.out.println("Match files: " + mMatchFiles);
         List<ITarget> targets = new ArrayList<ITarget>();
         for (File match : mMatchFiles) {
             String filename = match.getName();
@@ -124,14 +157,30 @@ public class Match implements IMatch {
         // Create a thread for each target, but only start a thread if the number of targets that
         // aren't blocked is under MAX_THREADS. If all targets are blocked there is a deadlock.
         for (ITarget target : targets) {
+            target.setUp();
+        }
+        for (ITarget target : targets) {
             target.build();
         }
+        for (ITarget target : targets) {
+            target.tearDown();
+        }
+        // Create a thread for each target, but only start a thread if the number of targets that
+        // aren't blocked is under MAX_THREADS. If all targets are blocked there is a deadlock.
         // Look at the output files of a target and all the files under the output directory,
         // delete files that were created in the last build but is no longer made by any targets.
         // This means all targets have to know their output files even if they dont need to build.
         // This is difficult for java compiles because you cannot know beforehand, given source
         // files, which classes will get generated because of inner/anonymous classes.
         // Could maybe be done by a target - it just gets built last.
+    }
+
+    /**
+     * {inheritDoc}
+     */
+    @Override
+    public void runCommand(String command) {
+        System.out.println(command);
     }
 
     /**

--- a/source/main/Target.java
+++ b/source/main/Target.java
@@ -19,6 +19,8 @@ import expression.function.IFunction;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class Target implements ITarget {
 
@@ -35,6 +37,7 @@ public class Target implements ITarget {
     /**
      * {inheritDoc}
      */
+    @Override
     public void setFunction(IFunction function) {
         mFunction = function;
     }
@@ -42,8 +45,26 @@ public class Target implements ITarget {
     /**
      * {inheritDoc}
      */
+    @Override
+    public void setUp() {
+        mFunction.setUp();
+    }
+
+    /**
+     * {inheritDoc}
+     */
+    @Override
     public void build() {
         mFunction.resolve();
         // TODO put this target's input and output files in the database
     }
+
+    /**
+     * {inheritDoc}
+     */
+    @Override
+    public void tearDown() {
+        mFunction.tearDown();
+    }
+
 }

--- a/source/main/Utilities.java
+++ b/source/main/Utilities.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2015 Stuart Scott
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package main;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class Utilities {
+
+    private Utilities() {}
+
+    public static <T> String join(String separator, List<T> values) {
+        StringBuilder sb = new StringBuilder();
+        boolean first = true;
+        for (T value : values) {
+            if (first) {
+                first = false;
+            } else {
+                sb.append(separator);
+            }
+            sb.append(value.toString());
+        }
+        return sb.toString();
+    }
+
+    public static <T> List<T> newList(T element) {
+        List<T> list = new ArrayList<T>();
+        list.add(element);
+        return list;
+    }
+}

--- a/tests/source/expression/ExpressionListTest.java
+++ b/tests/source/expression/ExpressionListTest.java
@@ -31,7 +31,7 @@ public class ExpressionListTest {
 
     private static final String FOO = "foo";
     private static final String BAR = "bar";
-    private static final String EXPECTED = "foo;bar";
+    private static final String EXPECTED = "foo bar";
 
     @Test
     public void list() {

--- a/tests/source/expression/function/FindTest.java
+++ b/tests/source/expression/function/FindTest.java
@@ -16,7 +16,6 @@
 package expression.function;
 
 import expression.Expression;
-import expression.ExpressionList;
 import expression.IExpression;
 import expression.Literal;
 import main.IMatch;
@@ -28,6 +27,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -37,7 +37,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-public class GetFilesTest {
+public class FindTest {
 
     private static final String FOO = "foo";
     private static final String BAR = ".*/bar";
@@ -70,7 +70,7 @@ public class GetFilesTest {
 
     @Test
     public void resolveNamed() {
-        resolve(FILESB, GetFiles.DIRECTORY, mRoot.getAbsolutePath(), GetFiles.PATTERN, BAR);
+        resolve(FILESB, Find.DIRECTORY, mRoot.getAbsolutePath(), Find.PATTERN, BAR);
     }
 
     private void resolve(Set<String> expected, String... values) {
@@ -80,9 +80,10 @@ public class GetFilesTest {
         for (int i = 0; i < values.length; i++) {
             parameters.put(values[i], new Literal(match, target, values[++i]));
         }
-        IFunction function = new GetFiles(match, target, parameters);
-        String[] actual = function.resolve().split(ExpressionList.SEPARATOR);
-        Assert.assertEquals("Wrong number of files", expected.size(), actual.length);
+        IFunction function = new Find(match, target, parameters);
+        function.setUp();
+        List<String> actual = function.resolveList();
+        Assert.assertEquals("Wrong number of files", expected.size(), actual.size());
         for (String file : actual) {
             Assert.assertTrue(String.format("%s not found", file), expected.contains(file));
         }

--- a/tests/source/expression/function/FunctionTest.java
+++ b/tests/source/expression/function/FunctionTest.java
@@ -62,8 +62,10 @@ public class FunctionTest {
     public void getFunction() {
         IFunction function = Function.getFunction(FAKE, mMatch, mTarget, mParameters);
         Assert.assertNotNull("Expected to get function", function);
+        function.setUp();
         Assert.assertEquals("Wrong function resolution", FOO + BAR, function.resolve());
         Mockito.verify(mMatch, Mockito.never()).error(Mockito.anyString());
         Mockito.verify(mMatch, Mockito.never()).error(Mockito.<Exception>anyObject());
     }
+
 }

--- a/tests/source/expression/function/JavaJarTest.java
+++ b/tests/source/expression/function/JavaJarTest.java
@@ -29,22 +29,23 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-public class GetTest {
+public class JavaJarTest {
 
-    private static final String FOO = "foo";
-    private static final String BAR = "bar";
+    private static final String COMMAND = "mkdir -p {build/java/classes/FooBar,build/java/jar} && javac  FooBar -d build/java/classes/FooBar && cd build/java/classes/FooBar && jar cfm build/java/jar/FooBar.jar build/java/classes/FooBar/MANIFEST.MF build/java/classes/FooBar";
+    private static final String FOOBAR = "FooBar";
+    private static final String JAR = "build/java/jar/FooBar.jar";
 
     @Test
-    public void get() {
+    public void javaJar() {
         IMatch match = Mockito.mock(IMatch.class);
         ITarget target = Mockito.mock(ITarget.class);
-        Mockito.when(match.getProperty(FOO)).thenReturn(BAR);
         Map<String, IExpression> parameters = new HashMap<String, IExpression>();
-        Literal literal = new Literal(match, target, FOO);
-        parameters.put(Function.ANONYMOUS, literal);
-        IFunction function = new Get(match, target, parameters);
+        parameters.put(Function.NAME, new Literal(match, target, FOOBAR));
+        parameters.put(Function.SOURCE, new Literal(match, target, FOOBAR));
+        IFunction function = new JavaJar(match, target, parameters);
         function.setUp();
-        Assert.assertEquals("Wrong resolution", BAR, function.resolve());
+        Assert.assertEquals("Wrong resolution", JAR, function.resolve());
+        Mockito.verify(match, Mockito.times(1)).runCommand(Mockito.eq(COMMAND));
     }
 
 }

--- a/tests/source/expression/function/SetFileTest.java
+++ b/tests/source/expression/function/SetFileTest.java
@@ -22,32 +22,59 @@ import main.IMatch;
 import main.ITarget;
 import main.Match;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Assert;
+import org.junit.After;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.Matchers;
 
-public class SetTest {
+public class SetFileTest {
 
-    private static final String BAR = "bar";
     private static final String FOO = "foo";
+    private static final String BAR = "bar";
     private static final String NAME = "name";
     private static final String VALUE = "value";
 
-    @Test
-    public void set() {
-        IMatch match = Mockito.mock(IMatch.class);
-        ITarget target = Mockito.mock(ITarget.class);
-        Map<String, IExpression> parameters = new HashMap<String, IExpression>();
-        parameters.put(NAME, new Literal(match, target, FOO));
-        parameters.put(VALUE, new Literal(match, target, BAR));
-        IFunction function = new Set(match, target, parameters);
-        function.setUp();
-        Assert.assertEquals("Wrong function resolution", BAR, function.resolve());
-        Mockito.verify(match, Mockito.times(1)).setProperty(FOO, BAR);
+    private File mFile = null;
+    private String mFilename;
+
+    @After
+    public void tearDown() {
+        if (mFile != null) {
+            mFile.delete();
+            mFile = null;
+        }
     }
 
+    @Test
+    public void setFile() {
+        IMatch match = Mockito.mock(IMatch.class);
+        ITarget target = Mockito.mock(ITarget.class);
+        mFile = SetFileTest.setFile(match, target);
+        mFilename = mFile.getAbsolutePath();
+        Mockito.verify(match, Mockito.times(1)).setProperty(FOO, mFilename);
+        Mockito.verify(match, Mockito.times(1)).addFile(mFilename);
+        Mockito.verify(match, Mockito.times(1)).provideFile(mFilename);
+    }
+
+    static File setFile(IMatch match, ITarget target) {
+        File file = null;
+        try {
+            file = File.createTempFile(FOO, BAR);
+        } catch (IOException e) {
+            Assert.fail(e.getMessage());
+        }
+        Map<String, IExpression> parameters = new HashMap<String, IExpression>();
+        parameters.put(NAME, new Literal(match, target, FOO));
+        parameters.put(VALUE, new Literal(match, target, file.getAbsolutePath()));
+        IFunction function = new SetFile(match, target, parameters);
+        function.setUp();
+        function.resolve();
+        return file;
+    }
 }

--- a/tests/source/frontend/ParserTest.java
+++ b/tests/source/frontend/ParserTest.java
@@ -119,7 +119,7 @@ public class ParserTest {
         Assert.assertEquals("Incorrect parameter", "foobar", parameter.resolve());
         parameter = parameters.get("values");
         Assert.assertNotNull("Expected parameter", parameter);
-        Assert.assertEquals("Incorrect values", "bar;far", parameter.resolve());
+        Assert.assertEquals("Incorrect values", "bar far", parameter.resolve());
     }
 
     @Test

--- a/tests/source/main/AllTests.java
+++ b/tests/source/main/AllTests.java
@@ -20,11 +20,13 @@ import org.junit.runner.RunWith;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
+    expression.function.FindTest.class,
     expression.function.FunctionTest.class,
-    expression.function.GetFilesTest.class,
+    expression.function.GetFileTest.class,
     expression.function.GetTest.class,
+    expression.function.JavaJarTest.class,
+    expression.function.SetFileTest.class,
     expression.function.SetTest.class,
-    expression.ExpressionListTest.class,
     expression.LiteralTest.class,
     frontend.LexerTest.class,
     frontend.ParserTest.class,


### PR DESCRIPTION
A target will use addFile to register the output file, then call provideFile when the file is ready for other targets to use. When a target needs an input file, it will call awaitFile which will block the thread until that files is ready.

This mechanism is used by JavaJar, which is a build function that can create a .jar file from a set of source files. A sample program uses this rule to create its .jar files.