### PR TITLE
Enable parallel builds.

### DIFF
--- a/Match
+++ b/Match
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ant test && java -jar out/java/jar/Match.jar sample/
+ant test && java -jar out/java/jar/Match.jar .

--- a/build.xml
+++ b/build.xml
@@ -25,7 +25,7 @@
     <property name="main-class" value="main.Match"/>
 
     <path id="classpath">
-        <fileset dir="${libraries.directory}" includes="**/*.jar"/>
+        <fileset dir="${libraries.directory}" includes="**/*.jar" excludes="**/Match*"/>
         <pathelement location="${classes.directory}" />
         <pathelement location="${classes.tests.directory}" />
     </path>

--- a/match
+++ b/match
@@ -14,17 +14,17 @@
 
 Set(
     name = "junit"
-    value = "libraries/junit-4.12.jar"
+    value = "./libraries/junit-4.12.jar"
 )
 
 Set(
     name = "hamcrest"
-    value = "libraries/hamcrest-core-1.3.jar"
+    value = "./libraries/hamcrest-core-1.3.jar"
 )
 
 Set(
     name = "mockito"
-    value = "libraries/mockito-all-1.10.19.jar"
+    value = "./libraries/mockito-all-1.10.19.jar"
 )
 
 JavaJar(

--- a/source/expression/function/Find.java
+++ b/source/expression/function/Find.java
@@ -47,12 +47,12 @@ public class Find extends Function {
      */
     @Override
     public void configure() {
-        String match = mTarget.getFile();
-        int index = match.lastIndexOf('/');
-        File root = new File(match.substring(0, index));
+        int index = new File(".").getAbsolutePath().length() - 1;
+        File root = mTarget.getFile().getParentFile();
         File directory = new File(root, mDirectory.resolve());
+        String path = directory.getAbsolutePath().substring(index);
         String pattern = mPattern == null ? ".*" : mPattern.resolve();
-        scanFiles(directory, mFiles, Pattern.compile(pattern));
+        scanFiles(directory, path, mFiles, Pattern.compile(pattern));
     }
 
     /**
@@ -68,15 +68,15 @@ public class Find extends Function {
         return files;
     }
 
-    private static void scanFiles(File directory, List<String> files, Pattern pattern) {
+    private static void scanFiles(File directory, String path, List<String> files, Pattern pattern) {
         for (File file : directory.listFiles()) {
+            String fullname = String.format("%s/%s", path, file.getName());
             if (file.isFile()) {
-                String fullname = file.getAbsolutePath();
                 if (pattern.matcher(fullname).matches()) {
                     files.add(fullname);
                 }
             } else {
-                scanFiles(file, files, pattern);
+                scanFiles(file, fullname, files, pattern);
             }
         }
     }

--- a/source/expression/function/Function.java
+++ b/source/expression/function/Function.java
@@ -19,16 +19,19 @@ import expression.Expression;
 import expression.IExpression;
 import main.IMatch;
 import main.ITarget;
+
+import java.io.File;
 import java.lang.reflect.Constructor;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
 public abstract class Function extends Expression implements IFunction {
 
     public static final String ANONYMOUS = "_";
-    public static final String CLASS_OUTPUT = "out/java/classes";
+    public static final String CLASS_OUTPUT = "./out/java/classes";
     public static final String DIRECTORY = "directory";
-    public static final String JAR_OUTPUT = "out/java/jar";
+    public static final String JAR_OUTPUT = "./out/java/jar";
     public static final String LIBRARY = "library";
     public static final String MAIN_CLASS = "main_class";
     public static final String NAME = "name";
@@ -82,5 +85,4 @@ public abstract class Function extends Expression implements IFunction {
             return null;
         }
     }
-
 }

--- a/source/expression/function/JavaJUnit.java
+++ b/source/expression/function/JavaJUnit.java
@@ -15,9 +15,12 @@
  */
 package expression.function;
 
+import java.io.File;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import main.IMatch;
 import main.ITarget;
@@ -27,9 +30,9 @@ import expression.Literal;
 
 public class JavaJUnit extends Function {
 
-    private static final String RESULT_OUTPUT = "out/results";
+    private static final String RESULT_OUTPUT = "./out/results";
     private static final String MKDIR_COMMAND = "mkdir -p %s";
-    private static final String RUN_COMMAND = "java %s org.junit.runner.JUnitCore %s > %s";
+    private static final String RUN_COMMAND = "java %s org.junit.runner.JUnitCore %s | tee %s";
 
     private String mName;
     private String mMainClass;
@@ -65,14 +68,18 @@ public class JavaJUnit extends Function {
     @Override
     public String resolve() {
         List<String> libraries = new ArrayList<>();
+        Set<String> libs = new HashSet<>();
+        libs.add("junit");
+        libs.add("hamcrest");
+        libs.add("mockito");
         if (hasParameter(LIBRARY)) {
             for (String library : getParameter(LIBRARY).resolveList()) {
-                libraries.add(mMatch.getProperty(library));
+                libs.add(library);
             }
         }
-        libraries.add(mMatch.getProperty("junit"));
-        libraries.add(mMatch.getProperty("hamcrest"));
-        libraries.add(mMatch.getProperty("mockito"));
+        for (String library : libs) {
+            libraries.add(mMatch.getProperty(library));
+        }
         String classpath = String.format("-cp %s", Utilities.join(":", libraries));
         mMatch.runCommand(String.format(MKDIR_COMMAND, RESULT_OUTPUT));
         mMatch.runCommand(String.format(RUN_COMMAND, classpath, mMainClass, mOutput));

--- a/source/expression/function/JavaJar.java
+++ b/source/expression/function/JavaJar.java
@@ -21,6 +21,7 @@ import main.IMatch;
 import main.ITarget;
 import main.Utilities;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -75,7 +76,9 @@ public class JavaJar extends Function {
         String jarClasspath = "";
         if (hasParameter(LIBRARY)) {
             for (String library : getParameter(LIBRARY).resolveList()) {
-                libraries.add(mMatch.getProperty(library));
+                String path = mMatch.getProperty(library);
+                mMatch.awaitFile(path);
+                libraries.add(path);
             }
             javacClasspath = String.format("-cp %s", Utilities.join(":", libraries));
             jarClasspath = String.format("Class-Path: %s\n", Utilities.join(":", libraries));

--- a/source/frontend/ILexer.java
+++ b/source/frontend/ILexer.java
@@ -15,7 +15,14 @@
  */
 package frontend;
 
+import java.io.File;
+
 public interface ILexer {
+
+    /**
+     * Gets the file being parsed.
+     */
+    File getFile();
 
     /**
      * Gets the filename being parsed.

--- a/source/frontend/Lexer.java
+++ b/source/frontend/Lexer.java
@@ -17,6 +17,9 @@ package frontend;
 
 import main.IMatch;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.io.IOException;
 import java.util.List;
@@ -24,6 +27,7 @@ import java.util.List;
 public class Lexer implements ILexer {
 
     public IMatch mMatch;
+    public File mFile;
     public String mFilename;
     public int mLineNumber = 1;
     public List<Lexem> mLexems;
@@ -35,11 +39,24 @@ public class Lexer implements ILexer {
     public String mNextValue;
     public Token mCurrentToken;
 
-    public Lexer(IMatch match, List<Lexem> lexems, String filename, InputStream input) {
+    public Lexer(IMatch match, List<Lexem> lexems, File file) {
         mMatch = match;
         mLexems = lexems;
-        mFilename = filename;
-        mInput = input;
+        mFile = file;
+        mFilename = file.getAbsolutePath();
+        try {
+            mInput = new FileInputStream(file);
+        } catch (FileNotFoundException e) {
+            mMatch.error(e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public File getFile() {
+        return mFile;
     }
 
     /**

--- a/source/frontend/Parser.java
+++ b/source/frontend/Parser.java
@@ -24,6 +24,7 @@ import main.IMatch;
 import main.ITarget;
 import main.Target;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -33,13 +34,13 @@ public class Parser implements IParser {
 
     private ILexer mLexer;
     private IMatch mMatch;
-    private String mFile;
+    private File mFile;
     private ITarget mTarget;
 
     public Parser(IMatch match, ILexer lexer) {
         mMatch = match;
         mLexer = lexer;
-        mFile = lexer.getFilename();
+        mFile = lexer.getFile();
     }
 
     /**

--- a/source/main/IMatch.java
+++ b/source/main/IMatch.java
@@ -28,14 +28,14 @@ public interface IMatch {
     void setProperty(String key, String value);
 
     /**
-     * Prints the message to the console.
-     */
-    void print(String message);
-
-    /**
      * Prints the warning to the console.
      */
     void warn(String message);
+
+    /**
+     * Prints the message to the console.
+     */
+    void println(String message);
 
     /**
      * Aborts the build and prints the message to the console.
@@ -68,14 +68,4 @@ public interface IMatch {
      * Runs the given command.
      */
     void runCommand(String command);
-
-    /**
-     * Sets whether the build runs silently.
-     */
-    void setQuiet(boolean quiet);
-
-    /**
-     * Sets whether the build prints verbosely.
-     */
-    void setVerbose(boolean verbose);
 }

--- a/source/main/ITarget.java
+++ b/source/main/ITarget.java
@@ -17,12 +17,14 @@ package main;
 
 import expression.function.IFunction;
 
+import java.io.File;
+
 public interface ITarget {
 
     /**
      * @return the match file
      */
-    String getFile();
+    File getFile();
 
     /**
      * Sets the function that will build this target.

--- a/source/main/Target.java
+++ b/source/main/Target.java
@@ -17,13 +17,15 @@ package main;
 
 import expression.function.IFunction;
 
+import java.io.File;
+
 public class Target implements ITarget {
 
     private IMatch mMatch;
-    private String mFile;
+    private File mFile;
     private IFunction mFunction;
 
-    public Target(IMatch match, String file) {
+    public Target(IMatch match, File file) {
         mMatch = match;
         mFile = file;
     }
@@ -32,7 +34,7 @@ public class Target implements ITarget {
      * {inheritDoc}
      */
     @Override
-    public String getFile() {
+    public File getFile() {
         return mFile;
     }
 
@@ -60,5 +62,4 @@ public class Target implements ITarget {
         mFunction.resolve();
         // TODO put this target's input and output files in the database
     }
-
 }

--- a/tests/source/expression/function/FindTest.java
+++ b/tests/source/expression/function/FindTest.java
@@ -47,7 +47,7 @@ public class FindTest {
     @Before
     public void setUp() throws IOException {
         mRoot = MatchTest.createFileStructure();
-        mRootPath = mRoot.getAbsolutePath();
+        mRootPath = mRoot.toString();
         filesA.add(String.format("%s/a/b", mRootPath));
         filesA.add(String.format("%s/c/d/e", mRootPath));
         filesA.add(String.format("%s/c/d/f", mRootPath));
@@ -73,7 +73,7 @@ public class FindTest {
     private void resolve(Set<String> expected, String... values) {
         IMatch match = Mockito.mock(IMatch.class);
         ITarget target = Mockito.mock(ITarget.class);
-        Mockito.when(target.getFile()).thenReturn(String.format("%s/match", mRootPath));
+        Mockito.when(target.getFile()).thenReturn(new File(mRoot, "match"));
         Map<String, IExpression> parameters = new HashMap<String, IExpression>();
         for (int i = 0; i < values.length; i++) {
             parameters.put(values[i], new Literal(match, target, values[++i]));

--- a/tests/source/expression/function/FunctionTest.java
+++ b/tests/source/expression/function/FunctionTest.java
@@ -19,6 +19,7 @@ import expression.IExpression;
 import expression.Literal;
 import main.IMatch;
 import main.ITarget;
+
 import java.util.HashMap;
 import java.util.Map;
 

--- a/tests/source/expression/function/JavaJUnitTest.java
+++ b/tests/source/expression/function/JavaJUnitTest.java
@@ -21,6 +21,7 @@ import expression.Literal;
 import main.IMatch;
 import main.ITarget;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -32,22 +33,23 @@ import org.mockito.Mockito;
 
 public class JavaJUnitTest {
 
-    private static final String MKDIR_COMMAND = "mkdir -p out/results";
-    private static final String RUN_COMMAND = "java -cp out/java/jar/FooBar.jar:out/java/jar/FooBarTest.jar:libraries/junit.jar:libraries/hamcrest.jar:libraries/mockito.jar org.junit.runner.JUnitCore main.AllTests > out/results/FooBarTestResult";
+    private static final String RESULTS_OUT = "./out/results";
+    private static final String MKDIR_COMMAND = String.format("mkdir -p %s", RESULTS_OUT);
+    private static final String RUN_COMMAND = String.format("java -cp X:X:X:X:X org.junit.runner.JUnitCore main.AllTests | tee %s/FooBarTestResult", RESULTS_OUT);
     private static final String FOOBAR = "FooBar";
     private static final String FOOBAR_MAIN_CLASS = "main.AllTests";
     private static final String FOOBAR_RESULT = "FooBarTestResult";
     private static final String FOOBAR_TEST = "FooBarTest";
-    private static final String OUTPUT = "out/results/FooBarTestResult";
+    private static final String OUTPUT = String.format("%s/FooBarTestResult", RESULTS_OUT);
 
     @Test
     public void javaJUnit() {
         IMatch match = Mockito.mock(IMatch.class);
-        Mockito.when(match.getProperty("junit")).thenReturn("libraries/junit.jar");
-        Mockito.when(match.getProperty("hamcrest")).thenReturn("libraries/hamcrest.jar");
-        Mockito.when(match.getProperty("mockito")).thenReturn("libraries/mockito.jar");
-        Mockito.when(match.getProperty("FooBar")).thenReturn("out/java/jar/FooBar.jar");
-        Mockito.when(match.getProperty("FooBarTest")).thenReturn("out/java/jar/FooBarTest.jar");
+        Mockito.when(match.getProperty("junit")).thenReturn("X");
+        Mockito.when(match.getProperty("hamcrest")).thenReturn("X");
+        Mockito.when(match.getProperty("mockito")).thenReturn("X");
+        Mockito.when(match.getProperty("FooBar")).thenReturn("X");
+        Mockito.when(match.getProperty("FooBarTest")).thenReturn("X");
         ITarget target = Mockito.mock(ITarget.class);
         Map<String, IExpression> parameters = new HashMap<String, IExpression>();
         parameters.put(Function.NAME, new Literal(match, target, FOOBAR_RESULT));

--- a/tests/source/expression/function/JavaJarTest.java
+++ b/tests/source/expression/function/JavaJarTest.java
@@ -19,6 +19,8 @@ import expression.IExpression;
 import expression.Literal;
 import main.IMatch;
 import main.ITarget;
+
+import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,15 +30,18 @@ import org.mockito.Mockito;
 
 public class JavaJarTest {
 
-    private static final String MKDIR_COMMAND = "mkdir -p {out/java/classes/FooBar,out/java/jar}";
-    private static final String ECHO_COMMAND = "echo \"Manifest-Version: 1.0\nMain-Class: FooBar\n\" > out/java/classes/FooBar/MANIFEST.MF";
-    private static final String JAVAC_COMMAND = "javac  FooBar -d out/java/classes/FooBar";
-    private static final String JAR_COMMAND = "jar cfm out/java/jar/FooBar.jar out/java/classes/FooBar/MANIFEST.MF -C out/java/classes/FooBar .";
-    private static final String FOOBAR = "FooBar";
-    private static final String JAR = "out/java/jar/FooBar.jar";
+    private static final String CLASSES_OUT = "./out/java/classes/FooBar";
+    private static final String JARS_OUT = "./out/java/jar";
+    private static final String JAR_OUT = "./out/java/jar/FooBar.jar";
+    private static final String MANIFEST_OUT = "./out/java/classes/FooBar/MANIFEST.MF";
+    private static final String MKDIR_COMMAND = String.format("mkdir -p {%s,%s}", CLASSES_OUT, JARS_OUT);
+    private static final String ECHO_COMMAND = String.format("echo \"Manifest-Version: 1.0\nMain-Class: FooBar\n\" > %s", MANIFEST_OUT);
+    private static final String JAVAC_COMMAND = String.format("javac  FooBar -d %s", CLASSES_OUT);
+    private static final String JAR_COMMAND = String.format("jar cfm %s %s -C %s .", JAR_OUT, MANIFEST_OUT, CLASSES_OUT);
 
     @Test
     public void javaJar() {
+        final String FOOBAR = "FooBar";
         IMatch match = Mockito.mock(IMatch.class);
         ITarget target = Mockito.mock(ITarget.class);
         Map<String, IExpression> parameters = new HashMap<String, IExpression>();
@@ -45,7 +50,7 @@ public class JavaJarTest {
         parameters.put(Function.MAIN_CLASS, new Literal(match, target, FOOBAR));
         IFunction function = new JavaJar(match, target, parameters);
         function.configure();
-        Assert.assertEquals("Wrong resolution", JAR, function.resolve());
+        Assert.assertEquals("Wrong resolution", JAR_OUT, function.resolve());
         Mockito.verify(match, Mockito.times(1)).runCommand(Mockito.eq(MKDIR_COMMAND));
         Mockito.verify(match, Mockito.times(1)).runCommand(Mockito.eq(ECHO_COMMAND));
         Mockito.verify(match, Mockito.times(1)).runCommand(Mockito.eq(JAVAC_COMMAND));

--- a/tests/source/frontend/ParserTest.java
+++ b/tests/source/frontend/ParserTest.java
@@ -15,8 +15,10 @@
  */
 package frontend;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -44,9 +46,16 @@ public class ParserTest {
 
     @Test
     public void parse() {
-        String input = "FunctionFake(name = \"Target1\") FunctionFake(name = \"Target2\")";
-        InputStream in = new ByteArrayInputStream(input.getBytes());
-        Lexer lexer = new Lexer(mMatch, Match.LEXEMS, Match.MATCH, in);
+        File file = null;
+        try {
+            file = File.createTempFile("match", ".tmp");
+            BufferedWriter writer = new BufferedWriter(new FileWriter(file));
+            writer.write("FunctionFake(name = \"Target1\") FunctionFake(name = \"Target2\")");
+            writer.close();
+        } catch (IOException e) {
+            Assert.fail("Error while writing temp file " + e.getMessage());
+        }
+        Lexer lexer = new Lexer(mMatch, Match.LEXEMS, file);
         Parser parser = new Parser(mMatch, lexer);
         List<ITarget> targets = parser.parse();
         Assert.assertEquals("Incorrect number of targets", 2, targets.size());

--- a/tests/source/main/MatchTest.java
+++ b/tests/source/main/MatchTest.java
@@ -19,13 +19,27 @@ import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 public class MatchTest {
 
     private static final String FOO = "foo";
     private static final String BAR = "bar";
+
+    private File mRoot;
+
+    @Before
+    public void setUp() throws IOException {
+        mRoot = createFileStructure();
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        deleteFileStructure(mRoot);
+    }
 
     @Test
     public void properties() throws Exception {
@@ -70,21 +84,19 @@ public class MatchTest {
 
     @Test
     public void loadFiles() throws Exception {
-        File root = createFileStructure();
-        Match match = createMatch(root);
+        Match match = createMatch(mRoot);
         match.light();
         Assert.assertEquals("Wrong number of files", 4, match.getAllFiles().size());
     }
 
     private Match createMatch(File root) {
         Match match = new Match(root);
-        match.setQuiet(true);
+        match.mQuiet = true;
         return match;
     }
 
     public static File createFileStructure() throws IOException {
-        File root = File.createTempFile("temp", Long.toString(System.currentTimeMillis())); 
-        root.delete();
+        File root = new File("temp" + Long.toString(System.currentTimeMillis()));
         root.mkdirs();
         Assert.assertTrue("Root doesn't exist", root.exists());
         Assert.assertTrue("Root isn't a directory", root.isDirectory());
@@ -113,6 +125,7 @@ public class MatchTest {
                 child.delete();
             }
         }
+        directory.delete();
     }
 
     private static class Worker extends Thread {

--- a/tests/source/main/TargetTest.java
+++ b/tests/source/main/TargetTest.java
@@ -19,6 +19,8 @@ import expression.function.IFunction;
 import main.IMatch;
 import main.ITarget;
 
+import java.io.File;
+
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -28,7 +30,7 @@ public class TargetTest {
     public void build() {
         IMatch match = Mockito.mock(IMatch.class);
         IFunction function = Mockito.mock(IFunction.class);
-        ITarget target = new Target(match, "/tmp/match");
+        ITarget target = new Target(match, new File("/tmp/match"));
         target.setFunction(function);
         target.build();
         Mockito.verify(function, Mockito.times(1)).resolve();


### PR DESCRIPTION
This change builds each target in a separate thread, which declare the files they will add, and when. Targets that need a file will await it, synchronizing the targets.

This is a very simple implementation which could overload the host if the number of targets is high enough. A better (future) implementation could schedule N threads, and schedule more as targets block waiting for input files. It should also detect deadlocks.